### PR TITLE
Fix Private Scoreboard Bug

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -7,6 +7,7 @@ import subprocess
 import ast
 
 from api.models import Score, Score_r2, Score_r2_detection
+from app.models import Tfile1_r2
 from os import listdir
 from os.path import isfile, join
 from django.views.decorators.csrf import csrf_exempt

--- a/api/views.py
+++ b/api/views.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 import ast
 
-from api.models import Score, Score_r2
+from api.models import Score, Score_r2, Score_r2_detection
 from os import listdir
 from os.path import isfile, join
 from django.views.decorators.csrf import csrf_exempt
@@ -334,6 +334,9 @@ def postScore_r2(request):
                             obj.ref_acc = body['ref_acc']
                             obj.bucket = str(body['bucket'])
                             obj.save()
+                            files = Tfile1_r2.objects.get(user=User.object.get(username=orgName.split('-',1)[0]))
+                            files.fn += " " + orgName
+                            files.save()
                         else:
                             p = Score_r2.objects.create(
                                 filename=orgName,
@@ -348,6 +351,11 @@ def postScore_r2(request):
                                 message=body['message']
                                 )
                             p.save()
+                            files = Tfile1_r2.objects.create(
+                                user=User.object.get(username=orgName.split('-',1)[0])
+                                fn = orgName
+                                )
+                            files.save()
                     except Exception as exc:
                         return HttpResponse(exc)
 
@@ -394,6 +402,9 @@ def postScore_r2_detection(request):
                             obj.message = body['message']  
                             obj.metric = body['metric']  
                             obj.save()
+                            files = Tfile1_r2.objects.get(user=User.object.get(username=orgName.split('-',1)[0]))
+                            files.fn += " " + orgName
+                            files.save()
                         else:
                             p = Score_r2_detection.objects.create(
                                 filename=orgName,
@@ -404,6 +415,11 @@ def postScore_r2_detection(request):
                                 message=body['message']
                                 )
                             p.save()
+                            files = Tfile1_r2.objects.create(
+                                user=User.object.get(username=orgName.split('-',1)[0])
+                                fn = orgName
+                                )
+                            files.save()
                     except Exception as exc:
                         return HttpResponse(exc)
 

--- a/app/views.py
+++ b/app/views.py
@@ -743,7 +743,7 @@ def score_board_r2(request):
     userBucket = []
 
     try:
-        fn = user.tfile1_r2.fn
+        fn = Tfile1_r2.objects.get(user=user).fn
         fnList = fn.split(" ")
 
         for item in fnList:
@@ -786,7 +786,7 @@ def score_board_r2(request):
     userMetricDetectScore = []
 
     try:
-        fn = user.tfile1_r2.fn
+        fn = Tfile1_r2.objects.get(user=user).fn
         fnList = fn.split(" ")
 
         for item in fnList:


### PR DESCRIPTION
The app uses the Tfile1_r2 table to find out which submissions belong to which organization in order to make their private scoreboards. The current version of the API was not updating this table, meaning that everyone's private scoreboards were blank.
This pull request fixes the bug by augmenting an organization's Tfile1_r2 string when their score gets posted.