### PR TITLE
Python 3.5.2 revert

### DIFF
--- a/LPIRC_2018_Track3_Submission/settings.py
+++ b/LPIRC_2018_Track3_Submission/settings.py
@@ -18,11 +18,12 @@ BASE_DIR =  os.path.dirname(PROJECT_ROOT)
 
 # Environment Variables Import
 try:
+    # See if local settings can be found. If so, the server is running locally. If not, it is running on production.
     import local_settings
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
     logging.warning('running on local')
     PRODUCTION = False
-except ModuleNotFoundError:
+except ImportError:
     PRODUCTION = True
 
 try:

--- a/app/views.py
+++ b/app/views.py
@@ -855,7 +855,7 @@ def score_board_r2(request):
         userBucket,
         userFeedback_message
         )
-    allRank = zip(
+    allRank = list(zip(
         filenameList, 
         ordinals(), 
         runtimeList,
@@ -866,7 +866,7 @@ def score_board_r2(request):
         metricList,
         ref_accList,
         bucketList
-        )
+        ))
     zipRank = filter(lambda score: score[9] == "[24.0, 36.0]", allRank)
     zipRank2 = filter(lambda score: score[9] != "[24.0, 36.0]", allRank)
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.6
+python-3.5.2


### PR DESCRIPTION
The site claims to be running on Python 3.6.6 but is actually running on 3.5.2. Fixes an issue caused by that in the checking of the production environment.